### PR TITLE
Remove usage of deprecated .spec.running field

### DIFF
--- a/administrator/ansible/roles/kubevirt/files/student-materials/vm_containerdisk.yml
+++ b/administrator/ansible/roles/kubevirt/files/student-materials/vm_containerdisk.yml
@@ -5,7 +5,7 @@ metadata:
     kubevirt.io/os: linux
   name: vm1
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/administrator/ansible/roles/kubevirt/files/student-materials/vm_datavolume.yml
+++ b/administrator/ansible/roles/kubevirt/files/student-materials/vm_datavolume.yml
@@ -6,7 +6,7 @@ metadata:
   name: vm2
   namespace: default
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/administrator/ansible/roles/kubevirt/files/student-materials/vm_multus1.yml
+++ b/administrator/ansible/roles/kubevirt/files/student-materials/vm_multus1.yml
@@ -6,7 +6,7 @@ metadata:
     kubevirt-vm: fedora-multus-1
   name: fedora-multus-1
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/administrator/ansible/roles/kubevirt/files/student-materials/vm_multus2.yml
+++ b/administrator/ansible/roles/kubevirt/files/student-materials/vm_multus2.yml
@@ -6,7 +6,7 @@ metadata:
     kubevirt-vm: fedora-multus-2
   name: fedora-multus-2
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/labs/lab004/lab004.md
+++ b/labs/lab004/lab004.md
@@ -37,7 +37,7 @@ Notice it's not running. This is because in its YAML definition we can find the 
 ```
 ...
 spec:
-  running: false
+  runStrategy: Halted
 ...
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The .spec.running field is deprecated, therefore we should runStrategy instread.

For more info, look at:
https://github.com/kubevirt/kubevirt/issues/11993

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
